### PR TITLE
F2calv/2026 03 update2

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,70 @@
+# Copilot Instructions
+
+## GitHub Actions
+
+### General
+
+- Always leave **one blank line between steps** within a job for readability.
+- Pin actions to the **major version tag version by default** (e.g. `actions/checkout@v6`, `softprops/action-gh-release@v2`). Do not use SHA pinning or include minor/patch versions.
+- Set `fetch-depth: 0` on `actions/checkout` whenever GitVersion is used so it can read the full commit history. For lint-only workflows where history is unnecessary, `fetch-depth: 1` is acceptable.
+- Use explicit `permissions` blocks on every job; default to the minimum required (e.g. `contents: read`). Set global workflow-level permissions to `permissions: {}` (deny all) and grant per-job.
+
+### Step Naming
+
+- **One-liners**: When a step's `run` block is a single command, use that command (or a slightly abbreviated form) as the step `name` rather than a descriptive prose label (e.g. `name: npm install --global json5`, not `name: setup json5`).
+- **Multi-part setup**: When a setup requires multiple steps, name each step with a `(N of M)` suffix (e.g. `name: setup yq (1 of 3)`, `name: setup yq (2 of 3)`, `name: setup yq (3 of 3)`).
+- **Matrix-based names**: Include matrix variables in step names for identification (e.g. `name: test (${{ matrix.gv-source }}, ${{ matrix.gv-config }})`).
+
+### Naming Conventions
+
+- **Inputs/outputs**: kebab-case (e.g. `image-registry`, `tag-override`, `git-user-name`).
+- **Environment variables**: ALL_UPPERCASE with underscores (e.g. `IMAGE_REGISTRY`, `TAG_OVERRIDE`, `MANIFEST_PATHS`).
+- **Secrets**: ALL_UPPERCASE with underscores (e.g. `GITHUB_TOKEN`, `GH_PAT_GITOPS`, `NUGET_API_KEY`).
+
+### YAML Style
+
+- **2-space indentation** for all workflow and action YAML files.
+- Do not quote strings unless YAML requires it (e.g. values containing special characters, reserved words like `true`/`false`/`null`, or strings that could be misinterpreted as another type).
+- For `workflow_dispatch` string inputs that represent booleans, use quoted defaults (e.g. `default: 'true'`).
+- Use `|` (pipe) for multi-line `run` scripts. Use `>` for flowing multi-line description text.
+- One blank line between major YAML sections (`on:`, `env:`, `jobs:`). No blank lines within input/output lists.
+
+### Reusable Workflows
+
+- **File naming**: Prefix reusable workflow filenames with an underscore to distinguish them from top-level entry-point workflows (e.g. `_gitops-helm-update.yml`, `_deploy-maui-android.yml`).
+- **Same repo**: `uses: ./.github/workflows/_filename.yml`
+- **Cross-repo**: `uses: owner/repo/.github/workflows/filename.yml@v1`
+- Prefer `secrets: inherit` unless there is a specific reason to restrict secrets passed to the called workflow.
+
+### Composite Actions
+
+- Declare `shell: bash` explicitly on every `run` step — composite actions do not inherit a default shell.
+- Reference scripts relative to the action root using `${{ github.action_path }}/scripts/name.sh`.
+
+### Security
+
+- Deny all permissions at workflow level (`permissions: {}`), grant only what each job requires.
+- Skip bot-triggered runs conditionally: `if: github.actor != 'dependabot[bot]'`.
+- Pass tokens via `stdin` for registry logins (e.g. `echo "$TOKEN" | docker login --password-stdin`).
+- OCI registry, repository and tag values must be forced to lowercase (e.g. `${IMAGE_REGISTRY,,}`).
+
+### GitVersion
+
+- Always set `fetch-depth: 0` on checkout when GitVersion is in use.
+- Default config file is `GitVersion.yml` in the repository root.
+- Prefer `semVer` for tags and releases; use `fullSemVer` for display and pre-release identifiers.
+
+## Documentation
+
+### README Consistency
+
+- Every project's `README.md` must stay in sync with its implementation. During any refactoring — and **always** before creating a new PR — scan the `README.md` for inconsistencies: outdated input/output names, missing or removed configuration options, or inaccurate examples. Update the README as part of the same change, not as a follow-up.
+- **Mermaid diagrams**: Use Mermaid diagrams in `README.md` files to illustrate GitHub Actions workflow chains. These diagrams make complex relationships immediately visible and must be kept in sync with the code they describe.
+
+## Copilot Workflow
+
+- **Preserve git history during renames/moves**: When renaming or relocating files, first perform the rename/move (preferably via `git mv`), then make content edits to the file in its new location/name. This two-step approach preserves git history across the rename. Do not delete-and-recreate files when a rename or move is the intent.
+
+## Misc
+
+- When detecting new conventions or patterns in the codebase, add them to this document and apply them retroactively where applicable.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -60,6 +60,7 @@
 
 - Every project's `README.md` must stay in sync with its implementation. During any refactoring — and **always** before creating a new PR — scan the `README.md` for inconsistencies: outdated input/output names, missing or removed configuration options, or inaccurate examples. Update the README as part of the same change, not as a follow-up.
 - **Mermaid diagrams**: Use Mermaid diagrams in `README.md` files to illustrate GitHub Actions workflow chains. These diagrams make complex relationships immediately visible and must be kept in sync with the code they describe.
+- **Markdown tables**: Table separator rows must use spaces around pipes to match the spaced style used in header and data rows (e.g. `| --- | --- |` not `|---|---|`). This prevents MD060 (table-column-style) warnings.
 
 ## Copilot Workflow
 

--- a/.github/prompts/summarize-for-pr.prompt.md
+++ b/.github/prompts/summarize-for-pr.prompt.md
@@ -1,5 +1,5 @@
 ---
-description: "Create a temporary markdown file summarising all branch changes vs. master for PR review"
+description: "Create a temporary markdown file summarising all branch changes vs. main/master for PR review"
 agent: "agent"
 ---
 

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,15 +1,15 @@
-mode: MainLine
+mode: ContinuousDeployment
 branches:
   main:
     regex: ^main$
-    tag: ""
+    label: ''
   feature:
     regex: ^features?[/-]
-    tag: useBranchName
+    label: useBranchName
   preview:
     regex: ^preview?[/-]
-    tag: preview-{BranchName}
-    source-branches: ["main"]
+    label: preview-{BranchName}
+    source-branches: [main]
 ignore:
   sha: []
 merge-message-formats: {}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GitHub Action: GitOps Manifest Update
 
-This GitHub Action updates image tags in GitOps YAML manifests (Kubernetes `Deployment` resources) and pushes the changes back to the source repository. It uses [yq](https://github.com/mikefarah/yq) to manipulate the manifest YAML in-place, setting the container image and `FULLSEMVER` environment variable on containers named `primary`.
+This GitHub Action updates image tags in GitOps YAML manifests (Kubernetes `Deployment` resources) and pushes the changes back to the source repository. It uses [yq](https://github.com/mikefarah/yq) to manipulate the manifest YAML in-place, setting the container image and `FULLSEMVER` environment variable (from `tag`) on containers named `primary`.
 
 The yq version is sourced from `.devcontainer/devcontainer.json` by default.
 
@@ -14,10 +14,10 @@ steps:
   with:
     image-registry: ghcr.io/f2calv
     image-repository: myapp
-    tag: 1.2.3
+    tag-override: 1.2.3
     manifest: myapp
     manifest-path: src/workloads
-    fullSemVer: 1.2.301-feature-my-feature.12
+    tag: 1.2.301-feature-my-feature.12
     git-repo-update: false
 
 # Complete usage example updates manifests and pushes to git.
@@ -25,10 +25,10 @@ steps:
   with:
     image-registry: ghcr.io/f2calv
     image-repository: prefix/myapp
-    tag: 1.2.3
+    tag-override: 1.2.3
     manifest: myapp
     manifest-path: src/workloads
-    fullSemVer: 1.2.301-feature-my-feature.12
+    tag: 1.2.301-feature-my-feature.12
 ```
 
 This action is also available as a [reusable workflow](https://github.com/f2calv/gha-workflows/blob/main/.github/workflows/gha-gitops-manifest-update.yml).
@@ -39,11 +39,11 @@ This action is also available as a [reusable workflow](https://github.com/f2calv
 | ----- | ---- | -------- | ------- | ----------- |
 | `image-registry` | string | ✅ | | Container registry e.g. `ghcr.io/gh-user`, `xyz.azurecr.io` or `docker.io` |
 | `image-repository` | string | ✅ | | Image repository e.g. `[optional-prefix/]myimage` |
-| `tag` | string | ✅ | | Image tag e.g. `latest`, `latest-dev`, `1.2.3` |
+| `tag-override` | string | ✅ | | Image tag override e.g. `latest`, `latest-dev`, `1.2.3` |
 | `devcontainer-path` | string | | `.devcontainer/devcontainer.json` | Path to `devcontainer.json` used to resolve yq version |
 | `manifest` | string | ✅ | | Manifest name(s) without file extension. Accepts multiple values separated by a space e.g. `deploy1 deploy2 deploy3` |
 | `manifest-path` | string | ✅ | | Path to manifest directory e.g. `src/workloads` |
-| `fullSemVer` | string | ✅ | | Full semantic version e.g. `1.2.301-feature-my-feature.12` |
+| `tag` | string | ✅ | | Full semantic version e.g. `1.2.301-feature-my-feature.12` |
 | `git-repo-update` | boolean | | `true` | If `false` then skips git operations entirely (demo mode) |
 | `git-user-name` | string | | `GitHub Actions Bot` | Git commit author name |
 | `git-user-email` | string | | `github-actions[bot]@users.noreply.github.com` | Git commit author email |

--- a/README.md
+++ b/README.md
@@ -1,47 +1,88 @@
 # GitHub Action: GitOps Manifest Update
 
-This GitHub Action updates image tags in GitOps YAML manifests (Kubernetes `Deployment` resources) and pushes the changes back to the source repository. It uses [yq](https://github.com/mikefarah/yq) to manipulate the manifest YAML in-place, setting the container image and `TAG` environment variable on containers named `primary`.
-
-The yq version is sourced from `.devcontainer/devcontainer.json` by default.
+This GitHub Action iterates over YAML manifests (Kubernetes `Deployment` or ArgoCD `Application`) and updates their image/tag. For ArgoCD `Application` manifests it also pulls and renders Helm charts. It uses [yq](https://github.com/mikefarah/yq) to manipulate manifest YAML in-place and [Helm](https://helm.sh/) for chart operations. Tool versions are sourced from `.devcontainer/devcontainer.json` by default.
 
 ## Examples
 
 ```yaml
 steps:
 
-# Minimal usage example updates manifests but does not push.
-- uses: f2calv/gha-gitops-manifest-update@v1
+# Deployment-only: updates image tag and pushes to git.
+- uses: f2calv/gha-gitops-manifest-update@v2
   with:
+    tag: 1.2.3
     image-registry: ghcr.io/f2calv
     image-repository: myapp
-    tag-override: 1.2.3
     manifest-paths: src/workloads/myapp.yaml
+    namespace: prd
+
+# Deployment with tag-override: image uses latest-dev, TAG env var tracks full semver.
+- uses: f2calv/gha-gitops-manifest-update@v2
+  with:
     tag: 1.2.301-feature-my-feature.12
+    tag-override: latest-dev
+    image-registry: ghcr.io/f2calv
+    image-repository: myapp
+    manifest-paths: src/workloads/myapp.yaml
+    namespace: dev
     git-repo-update: false
 
-# Complete usage example updates manifests and pushes to git.
-- uses: f2calv/gha-gitops-manifest-update@v1
+# ArgoCD Application: updates targetRevision, pulls and renders Helm chart.
+- uses: f2calv/gha-gitops-manifest-update@v2
   with:
+    tag: 1.2.3
     image-registry: ghcr.io/f2calv
-    image-repository: prefix/myapp
-    tag-override: 1.2.3
+    image-repository: myapp
+    chart-registry: ghcr.io/f2calv
+    chart-registry-username: f2calv
+    chart-registry-password: ${{ secrets.GITHUB_TOKEN }}
+    chart-repository: charts/myapp
     manifest-paths: src/workloads/myapp.yaml
-    tag: 1.2.301-feature-my-feature.12
+    namespace: prd
+    git-working-directory: gitops/
 ```
 
 This action is also available as a [reusable workflow](https://github.com/f2calv/gha-workflows/blob/main/.github/workflows/gha-gitops-manifest-update.yml).
 
 ## Inputs
 
+### Image
+
 | Input | Type | Required | Default | Description |
 | ----- | ---- | -------- | ------- | ----------- |
+| `tag` | string | ✅ | | Semantic version e.g. `1.2.3`, `1.2.3-branch-name.12` |
+| `tag-override` | string | | | Optional image tag override e.g. `latest`, `latest-dev`. When set the image uses this tag; when empty the image uses `tag` |
 | `image-registry` | string | ✅ | | Container registry e.g. `ghcr.io/gh-user`, `xyz.azurecr.io` or `docker.io` |
 | `image-repository` | string | ✅ | | Image repository e.g. `[optional-prefix/]myimage` |
-| `tag-override` | string | ✅ | | Image tag override e.g. `latest`, `latest-dev`, `1.2.3` |
-| `devcontainer-path` | string | | `.devcontainer/devcontainer.json` | Path to `devcontainer.json` used to resolve yq version |
+
+### Chart
+
+| Input | Type | Required | Default | Description |
+| ----- | ---- | -------- | ------- | ----------- |
+| `chart-registry` | string | | | Helm chart OCI registry e.g. `ghcr.io/gh-user` |
+| `chart-registry-username` | string | | | Registry username for `helm registry login` |
+| `chart-registry-password` | string | | | Registry password for `helm registry login` |
+| `chart-repository` | string | | | Chart repository path e.g. `[optional-prefix/]charts/myname` |
+
+### Manifest
+
+| Input | Type | Required | Default | Description |
+| ----- | ---- | -------- | ------- | ----------- |
 | `manifest-paths` | string | ✅ | | Space-separated YAML manifest paths e.g. `src/workloads/manifest1.yaml src/workloads/manifest2.yaml` |
-| `tag` | string | ✅ | | Full semantic version e.g. `1.2.301-feature-my-feature.12` |
+| `namespace` | string | ✅ | | Destination Kubernetes namespace e.g. `dev`, `prd` |
+
+### Tooling
+
+| Input | Type | Required | Default | Description |
+| ----- | ---- | -------- | ------- | ----------- |
+| `devcontainer-path` | string | | `.devcontainer/devcontainer.json` | Path to `devcontainer.json` used to resolve yq and Helm versions |
+
+### Git
+
+| Input | Type | Required | Default | Description |
+| ----- | ---- | -------- | ------- | ----------- |
 | `git-repo-update` | boolean | | `true` | If `false` then skips git operations entirely (demo mode) |
 | `git-user-name` | string | | `GitHub Actions Bot` | Git commit author name |
 | `git-user-email` | string | | `github-actions[bot]@users.noreply.github.com` | Git commit author email |
 | `git-branch-name` | string | | `main` | Branch to commit and push to |
+| `git-working-directory` | string | | `.` | Working directory for git operations e.g. `gitops/` |

--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ steps:
     image-registry: ghcr.io/f2calv
     image-repository: myapp
     tag-override: 1.2.3
-    manifest: myapp
-    manifest-path: src/workloads
+    manifest-paths: src/workloads/myapp.yaml
     tag: 1.2.301-feature-my-feature.12
     git-repo-update: false
 
@@ -26,8 +25,7 @@ steps:
     image-registry: ghcr.io/f2calv
     image-repository: prefix/myapp
     tag-override: 1.2.3
-    manifest: myapp
-    manifest-path: src/workloads
+    manifest-paths: src/workloads/myapp.yaml
     tag: 1.2.301-feature-my-feature.12
 ```
 
@@ -41,8 +39,7 @@ This action is also available as a [reusable workflow](https://github.com/f2calv
 | `image-repository` | string | ✅ | | Image repository e.g. `[optional-prefix/]myimage` |
 | `tag-override` | string | ✅ | | Image tag override e.g. `latest`, `latest-dev`, `1.2.3` |
 | `devcontainer-path` | string | | `.devcontainer/devcontainer.json` | Path to `devcontainer.json` used to resolve yq version |
-| `manifest` | string | ✅ | | Manifest name(s) without file extension. Accepts multiple values separated by a space e.g. `deploy1 deploy2 deploy3` |
-| `manifest-path` | string | ✅ | | Path to manifest directory e.g. `src/workloads` |
+| `manifest-paths` | string | ✅ | | Space-separated YAML manifest paths e.g. `src/workloads/manifest1.yaml src/workloads/manifest2.yaml` |
 | `tag` | string | ✅ | | Full semantic version e.g. `1.2.301-feature-my-feature.12` |
 | `git-repo-update` | boolean | | `true` | If `false` then skips git operations entirely (demo mode) |
 | `git-user-name` | string | | `GitHub Actions Bot` | Git commit author name |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GitHub Action: GitOps Manifest Update
 
-This GitHub Action updates image tags in GitOps YAML manifests (Kubernetes `Deployment` resources) and pushes the changes back to the source repository. It uses [yq](https://github.com/mikefarah/yq) to manipulate the manifest YAML in-place, setting the container image and `FULLSEMVER` environment variable (from `tag`) on containers named `primary`.
+This GitHub Action updates image tags in GitOps YAML manifests (Kubernetes `Deployment` resources) and pushes the changes back to the source repository. It uses [yq](https://github.com/mikefarah/yq) to manipulate the manifest YAML in-place, setting the container image and `TAG` environment variable on containers named `primary`.
 
 The yq version is sourced from `.devcontainer/devcontainer.json` by default.
 

--- a/README.md
+++ b/README.md
@@ -12,20 +12,19 @@ steps:
 # Minimal usage example updates manifests but does not push.
 - uses: f2calv/gha-gitops-manifest-update@v1
   with:
-    registry: ghcr.io/f2calv
-    repository: myapp
+    image-registry: ghcr.io/f2calv
+    image-repository: myapp
     tag: 1.2.3
     manifest: myapp
     manifest-path: src/workloads
     fullSemVer: 1.2.301-feature-my-feature.12
-    git-repository-push-enabled: false
+    git-repo-update: false
 
 # Complete usage example updates manifests and pushes to git.
 - uses: f2calv/gha-gitops-manifest-update@v1
   with:
-    registry: ghcr.io/f2calv
-    repository: myapp
-    repository-prefix: cas/
+    image-registry: ghcr.io/f2calv
+    image-repository: prefix/myapp
     tag: 1.2.3
     manifest: myapp
     manifest-path: src/workloads
@@ -38,15 +37,14 @@ This action is also available as a [reusable workflow](https://github.com/f2calv
 
 | Input | Type | Required | Default | Description |
 | ----- | ---- | -------- | ------- | ----------- |
-| `registry` | string | ✅ | | Container registry e.g. `ghcr.io/gh-user`, `xyz.azurecr.io` or `docker.io` |
-| `repository` | string | ✅ | | Deployment name(s). Accepts multiple values separated by a space e.g. `deploy1 deploy2 deploy3` |
-| `repository-prefix` | string | | `''` | Repository prefix e.g. `prefix/` |
+| `image-registry` | string | ✅ | | Container registry e.g. `ghcr.io/gh-user`, `xyz.azurecr.io` or `docker.io` |
+| `image-repository` | string | ✅ | | Image repository e.g. `[optional-prefix/]myimage` |
 | `tag` | string | ✅ | | Image tag e.g. `latest`, `latest-dev`, `1.2.3` |
 | `devcontainer-path` | string | | `.devcontainer/devcontainer.json` | Path to `devcontainer.json` used to resolve yq version |
 | `manifest` | string | ✅ | | Manifest name(s) without file extension. Accepts multiple values separated by a space e.g. `deploy1 deploy2 deploy3` |
 | `manifest-path` | string | ✅ | | Path to manifest directory e.g. `src/workloads` |
 | `fullSemVer` | string | ✅ | | Full semantic version e.g. `1.2.301-feature-my-feature.12` |
-| `git-repository-push-enabled` | boolean | | `true` | If `false` then skips git operations entirely (demo mode) |
+| `git-repo-update` | boolean | | `true` | If `false` then skips git operations entirely (demo mode) |
 | `git-user-name` | string | | `GitHub Actions Bot` | Git commit author name |
 | `git-user-email` | string | | `github-actions[bot]@users.noreply.github.com` | Git commit author email |
 | `git-branch-name` | string | | `main` | Branch to commit and push to |

--- a/action.yml
+++ b/action.yml
@@ -101,9 +101,9 @@ runs:
           #update the image tag
           yq -i '. | select(.kind == "Deployment") as $deployment | select(.kind != "Deployment") as $other | $deployment.spec.template.spec.containers[] |= select(.name == "primary").image=env(IMAGE) | ($deployment, $other)' $MANIFEST_PATH
 
-          #update the GIT_TAG env variable so we can track a deployment of new image tagged with latest-dev
-          FULLSEMVER=${{ inputs.tag }}
-          FULLSEMVER=$FULLSEMVER yq -i '. | select(.kind == "Deployment") as $deployment | select(.kind != "Deployment") as $other | $deployment.spec.template.spec.containers[] |= select(.name == "primary").env[] |= select(.name == "FULLSEMVER").value=env(FULLSEMVER) | ($deployment, $other)' $MANIFEST_PATH
+          #update the TAG env variable so we can track a deployment of a new image that has it's full sem ver tag overriden by tagged tag-override, e.g. latest-dev
+          TAG_VALUE=${{ inputs.tag }}
+          TAG_VALUE=$TAG_VALUE yq -i '. | select(.kind == "Deployment") as $deployment | select(.kind != "Deployment") as $other | $deployment.spec.template.spec.containers[] |= select(.name == "primary").env[] |= select(.name == "TAG").value=env(TAG_VALUE) | ($deployment, $other)' $MANIFEST_PATH
 
           cat $MANIFEST_PATH
 

--- a/action.yml
+++ b/action.yml
@@ -18,13 +18,9 @@ inputs:
     type: string
     description: e.g. .devcontainer/devcontainer.json
     default: .devcontainer/devcontainer.json
-  manifest:
+  manifest-paths:
     type: string
-    description: Accepts multiple manifest names (without file extension) when separated by a space e.g. deploy1 deploy2 deploy3 (deploy1.yaml etc...)
-    required: true
-  manifest-path:
-    type: string
-    description: e.g. src/workloads
+    description: Space-separated YAML manifests which need to be updated e.g. src/workloads/manifest1.yaml src/workloads/manifest2.yaml
     required: true
   tag:
     type: string
@@ -80,48 +76,37 @@ runs:
     - name: manipulate deployment
       shell: bash
       run: |
-        echo "repositories=${{ inputs.image-repository }}"
-        REPOSITORIES=(${{ inputs.image-repository }})
-        for chartname in "${REPOSITORIES[@]}"
+        MANIFEST_PATHS=(${{ inputs.manifest-paths }})
+        for MANIFEST_PATH in "${MANIFEST_PATHS[@]}"
         do
 
-          echo "manifests=${{ inputs.manifest }}"
-          MANIFESTS=(${{ inputs.manifest }})
-          for manifestpath in "${MANIFESTS[@]}"
-          do
+          echo "now processing manifest..."
+          export MANIFEST_PATH=$MANIFEST_PATH                                        # e.g. src/workloads/authenticator.yaml
+          export REGISTRY=${{ inputs.image-registry }}                               # e.g. ghcr.io/f2calv
+          export REPOSITORY=$REGISTRY/${{ inputs.image-repository }}                  # e.g. ghcr.io/f2calv/authenticator
+          export TAG=${{ inputs.tag-override }}                                      # e.g. 1.2.3
+          export IMAGE=$REPOSITORY:$TAG                                              # e.g. ghcr.io/f2calv/authenticator:1.2.3
 
-            echo "now processing chart..."
-            export CHART_NAME=$chartname                                             # e.g. authenticator
-            export MANIFEST_PATH=${{ inputs.manifest-path }}/$manifestpath.yaml      # e.g. src/workloads/authenticator.yaml
-            export CHART_REPOSITORY=$CHART_NAME # e.g. cas/charts/authenticator
-            export REGISTRY=${{ inputs.image-registry }}                             # e.g. ghcr.io/f2calv
-            export REPOSITORY=$REGISTRY/$CHART_NAME                                  # e.g. ghcr.io/f2calv/authenticator
-            export TAG=${{ inputs.tag-override }}                                    # e.g. 1.2.3
-            export IMAGE=$REPOSITORY:$TAG                                            # e.g. ghcr.io/f2calv/cas/authenticator:1.2.3
-  
-            echo "CHART_NAME=$CHART_NAME"
-            echo "MANIFEST_PATH=$MANIFEST_PATH"
-            echo "CHART_REPOSITORY=$CHART_REPOSITORY"
-            echo "REGISTRY=$REGISTRY"
-            echo "REPOSITORY=$REPOSITORY"
-            echo "TAG=$TAG"
-            echo "IMAGE=$IMAGE"
-  
-            if [[ ! -f $MANIFEST_PATH ]]; then
-               echo "::warning title=file $MANIFEST_PATH::File $MANIFEST_PATH does not exist!"
-               continue
-            fi
-  
-            #update the image tag
-            yq -i '. | select(.kind == "Deployment") as $deployment | select(.kind != "Deployment") as $other | $deployment.spec.template.spec.containers[] |= select(.name == "primary").image=env(IMAGE) | ($deployment, $other)' $MANIFEST_PATH
-  
-            #update the GIT_TAG env variable so we can track a deployment of new image tagged with latest-dev
-            FULLSEMVER=${{ inputs.tag }}
-            FULLSEMVER=$FULLSEMVER yq -i '. | select(.kind == "Deployment") as $deployment | select(.kind != "Deployment") as $other | $deployment.spec.template.spec.containers[] |= select(.name == "primary").env[] |= select(.name == "FULLSEMVER").value=env(FULLSEMVER) | ($deployment, $other)' $MANIFEST_PATH
-  
-            cat $MANIFEST_PATH
+          echo "MANIFEST_PATH=$MANIFEST_PATH"
+          echo "REGISTRY=$REGISTRY"
+          echo "REPOSITORY=$REPOSITORY"
+          echo "TAG=$TAG"
+          echo "IMAGE=$IMAGE"
 
-            done
+          if [[ ! -f $MANIFEST_PATH ]]; then
+             echo "::warning title=file $MANIFEST_PATH::File $MANIFEST_PATH does not exist!"
+             continue
+          fi
+
+          #update the image tag
+          yq -i '. | select(.kind == "Deployment") as $deployment | select(.kind != "Deployment") as $other | $deployment.spec.template.spec.containers[] |= select(.name == "primary").image=env(IMAGE) | ($deployment, $other)' $MANIFEST_PATH
+
+          #update the GIT_TAG env variable so we can track a deployment of new image tagged with latest-dev
+          FULLSEMVER=${{ inputs.tag }}
+          FULLSEMVER=$FULLSEMVER yq -i '. | select(.kind == "Deployment") as $deployment | select(.kind != "Deployment") as $other | $deployment.spec.template.spec.containers[] |= select(.name == "primary").env[] |= select(.name == "FULLSEMVER").value=env(FULLSEMVER) | ($deployment, $other)' $MANIFEST_PATH
+
+          cat $MANIFEST_PATH
+
         done
 
     - name: repo update

--- a/action.yml
+++ b/action.yml
@@ -84,13 +84,15 @@ runs:
           export MANIFEST_PATH=$MANIFEST_PATH                                        # e.g. src/workloads/authenticator.yaml
           export REGISTRY=${{ inputs.image-registry }}                               # e.g. ghcr.io/f2calv
           export REPOSITORY=$REGISTRY/${{ inputs.image-repository }}                 # e.g. ghcr.io/f2calv/authenticator
-          export TAG=${{ inputs.tag-override }}                                      # e.g. 1.2.3
-          export IMAGE=$REPOSITORY:$TAG                                              # e.g. ghcr.io/f2calv/authenticator:1.2.3
+          export TAG=${{ inputs.tag }}                                               # e.g. 1.2.301-feature-my-feature.12
+          export TAG_OVERRIDE=${{ inputs.tag-override }}                             # e.g. latest, latest-dev, 1.2.3
+          export IMAGE=$REPOSITORY:$TAG_OVERRIDE                                     # e.g. ghcr.io/f2calv/authenticator:1.2.3
 
           echo "MANIFEST_PATH=$MANIFEST_PATH"
           echo "REGISTRY=$REGISTRY"
           echo "REPOSITORY=$REPOSITORY"
           echo "TAG=$TAG"
+          echo "TAG_OVERRIDE=$TAG_OVERRIDE"
           echo "IMAGE=$IMAGE"
 
           if [[ ! -f $MANIFEST_PATH ]]; then
@@ -102,8 +104,7 @@ runs:
           yq -i '. | select(.kind == "Deployment") as $deployment | select(.kind != "Deployment") as $other | $deployment.spec.template.spec.containers[] |= select(.name == "primary").image=env(IMAGE) | ($deployment, $other)' $MANIFEST_PATH
 
           #update the TAG env variable so we can track a deployment of a new image that has it's full sem ver tag overriden by tagged tag-override, e.g. latest-dev
-          TAG_VALUE=${{ inputs.tag }}
-          TAG_VALUE=$TAG_VALUE yq -i '. | select(.kind == "Deployment") as $deployment | select(.kind != "Deployment") as $other | $deployment.spec.template.spec.containers[] |= select(.name == "primary").env[] |= select(.name == "TAG").value=env(TAG_VALUE) | ($deployment, $other)' $MANIFEST_PATH
+          yq -i '. | select(.kind == "Deployment") as $deployment | select(.kind != "Deployment") as $other | $deployment.spec.template.spec.containers[] |= select(.name == "primary").env[] |= select(.name == "TAG").value=env(TAG) | ($deployment, $other)' $MANIFEST_PATH
 
           cat $MANIFEST_PATH
 
@@ -114,11 +115,11 @@ runs:
       shell: bash
       run: |
         if [[ -n "$(git status --porcelain)" ]]; then
-          git config --global user.email "${{ inputs.git-user-email }}"
           git config --global user.name "${{ inputs.git-user-name }}"
+          git config --global user.email "${{ inputs.git-user-email }}"
           git checkout ${{ inputs.git-branch-name }}
           git add --all
-          git commit -m "bump '${{ inputs.image-repository }}' to '${{ inputs.tag-override }}'"
+          git commit -m "bump '${{ inputs.image-repository }}' to '${{ inputs.tag }}'"
           git push -v --progress
         else
           echo "::warning title=git push::No changes to push."

--- a/action.yml
+++ b/action.yml
@@ -83,7 +83,7 @@ runs:
           echo "now processing manifest..."
           export MANIFEST_PATH=$MANIFEST_PATH                                        # e.g. src/workloads/authenticator.yaml
           export REGISTRY=${{ inputs.image-registry }}                               # e.g. ghcr.io/f2calv
-          export REPOSITORY=$REGISTRY/${{ inputs.image-repository }}                  # e.g. ghcr.io/f2calv/authenticator
+          export REPOSITORY=$REGISTRY/${{ inputs.image-repository }}                 # e.g. ghcr.io/f2calv/authenticator
           export TAG=${{ inputs.tag-override }}                                      # e.g. 1.2.3
           export IMAGE=$REPOSITORY:$TAG                                              # e.g. ghcr.io/f2calv/authenticator:1.2.3
 

--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,15 @@
 name: gha-gitops-manifest-update
-description: Updates image tags in gitops manifests and optionally pushes changes to the git repository.
+description: Iterates over YAML manifests (Kubernetes Deployment or ArgoCD Application) and updates their image/tag - also renders manifests.
 
 inputs:
+  #image
+  tag:
+    type: string
+    description: e.g. 1.2.3, 1.2.3-branch-name.12
+    required: true
+  tag-override:
+    type: string
+    description: e.g. latest, latest-dev
   image-registry:
     type: string
     description: e.g. ghcr.io/gh-user, xyz.azurecr.io or docker.io
@@ -10,22 +18,32 @@ inputs:
     type: string
     description: e.g. [optional-prefix/]myimage
     required: true
-  tag-override:
+  #chart
+  chart-registry:
     type: string
-    description: e.g. latest, latest-dev, 1.2.3
-    required: true
-  devcontainer-path:
+    description: e.g. ghcr.io/gh-user, xyz.azurecr.io or docker.io
+  chart-registry-username:
     type: string
-    description: e.g. .devcontainer/devcontainer.json
-    default: .devcontainer/devcontainer.json
+  chart-registry-password:
+    type: string
+  chart-repository:
+    type: string
+    description: e.g. [optional-prefix/]charts/myname
+  #manifest
   manifest-paths:
     type: string
     description: Space-separated YAML manifests which need to be updated e.g. src/workloads/manifest1.yaml src/workloads/manifest2.yaml
     required: true
-  tag:
+  namespace:
     type: string
-    description: e.g. 1.2.301-feature-my-feature.12
+    description: Destination Kubernetes namespace for the application.
     required: true
+  #tooling
+  devcontainer-path:
+    type: string
+    description: e.g. .devcontainer/devcontainer.json
+    default: .devcontainer/devcontainer.json
+  #git
   git-repo-update:
     type: boolean
     description: If 'false' then skips the git operations entirely, e.g. action runs in demo mode
@@ -42,6 +60,10 @@ inputs:
     type: string
     description: e.g. main
     default: main
+  git-working-directory:
+    type: string
+    description: Working directory for git operations e.g. gitops/
+    default: .
 
 runs:
   using: composite
@@ -73,53 +95,154 @@ runs:
         sudo wget https://github.com/mikefarah/yq/releases/${{ env.VERSION_TO_INSTALL }}/download/yq_linux_amd64 -O /usr/bin/yq \
           && sudo chmod +x /usr/bin/yq
 
-    - name: manipulate deployment
+    - name: setup helm (1 of 2) #pull version from devcontainer.json
       shell: bash
       run: |
-        MANIFEST_PATHS=(${{ inputs.manifest-paths }})
-        for MANIFEST_PATH in "${MANIFEST_PATHS[@]}"
+        HELM_VERSION=$(cat ${{ inputs.devcontainer-path }} | jq -r '.features[] | select(.helm | . != null).helm')
+        echo "HELM_VERSION=$HELM_VERSION" >> $GITHUB_ENV
+        echo "HELM_VERSION=$HELM_VERSION"
+
+    - name: setup helm (2 of 2)
+      uses: azure/setup-helm@v5
+      with:
+        version: ${{ env.HELM_VERSION }}
+
+    #1. update the argocd application targetRevision to reflect the new helm chart version
+    #2. expand out the helm chart with new helm chart version (optional)
+    - run: |
+        #prefix manifest paths with git-working-directory if not '.'
+        GIT_DIR="${{ inputs.git-working-directory }}"
+        GIT_DIR="${GIT_DIR%/}"
+        RAW_PATHS="${{ inputs.manifest-paths }}"
+        MANIFEST_PATHS=""
+        for p in $RAW_PATHS; do
+          if [[ "$GIT_DIR" != "." ]]; then
+            MANIFEST_PATHS="$MANIFEST_PATHS $GIT_DIR/$p"
+          else
+            MANIFEST_PATHS="$MANIFEST_PATHS $p"
+          fi
+        done
+        MANIFEST_PATHS="${MANIFEST_PATHS# }"
+        printf "MANIFEST_PATHS=$MANIFEST_PATHS\n"
+        arr=($MANIFEST_PATHS)
+        for MANIFEST_PATH in "${arr[@]}"
         do
+          printf "\n-------------------------------------------"
 
-          echo "now processing manifest..."
-          export MANIFEST_PATH=$MANIFEST_PATH                                        # e.g. src/workloads/authenticator.yaml
-          export REGISTRY=${{ inputs.image-registry }}                               # e.g. ghcr.io/f2calv
-          export REPOSITORY=$REGISTRY/${{ inputs.image-repository }}                 # e.g. ghcr.io/f2calv/authenticator
-          export TAG=${{ inputs.tag }}                                               # e.g. 1.2.301-feature-my-feature.12
-          export TAG_OVERRIDE=${{ inputs.tag-override }}                             # e.g. latest, latest-dev, 1.2.3
-          export IMAGE=$REPOSITORY:$TAG_OVERRIDE                                     # e.g. ghcr.io/f2calv/authenticator:1.2.3
-
-          echo "MANIFEST_PATH=$MANIFEST_PATH"
-          echo "REGISTRY=$REGISTRY"
-          echo "REPOSITORY=$REPOSITORY"
-          echo "TAG=$TAG"
-          echo "TAG_OVERRIDE=$TAG_OVERRIDE"
-          echo "IMAGE=$IMAGE"
-
+          printf "\nMANIFEST_PATH=$MANIFEST_PATH"                                           # e.g. src/workloads/tickprocessor.yaml
           if [[ ! -f $MANIFEST_PATH ]]; then
-             echo "::warning title=file $MANIFEST_PATH::File $MANIFEST_PATH does not exist!"
-             continue
+              echo "::warning title=file $MANIFEST_PATH::File $MANIFEST_PATH does not exist!"
+              continue
           fi
 
-          #update the image tag
-          yq -i '. | select(.kind == "Deployment") as $deployment | select(.kind != "Deployment") as $other | $deployment.spec.template.spec.containers[] |= select(.name == "primary").image=env(IMAGE) | ($deployment, $other)' $MANIFEST_PATH
+          #force to lowercase
+          IMAGE_REGISTRY=${{ inputs.image-registry }}
+          IMAGE_REGISTRY=${IMAGE_REGISTRY,,}
+          IMAGE_REPOSITORY=${{ inputs.image-repository }}
+          IMAGE_REPOSITORY=${IMAGE_REPOSITORY,,}
+          CHART_REGISTRY=${{ inputs.chart-registry }}
+          CHART_REGISTRY=${CHART_REGISTRY,,}
+          CHART_REPOSITORY=${{ inputs.chart-repository }}
+          CHART_REPOSITORY=${CHART_REPOSITORY,,}
 
-          #update the TAG env variable so we can track a deployment of a new image that has it's full sem ver tag overriden by tagged tag-override, e.g. latest-dev
-          yq -i '. | select(.kind == "Deployment") as $deployment | select(.kind != "Deployment") as $other | $deployment.spec.template.spec.containers[] |= select(.name == "primary").env[] |= select(.name == "TAG").value=env(TAG) | ($deployment, $other)' $MANIFEST_PATH
+          export TAG=${{ inputs.tag }}                                                      # e.g. 1.2.3
+          export TAG_OVERRIDE=${{ inputs.tag-override }}                                    # e.g. latest, latest-dev
+          export IMAGE_REGISTRY=$IMAGE_REGISTRY                                             # e.g. ghcr.io
+          export IMAGE_REPOSITORY=$IMAGE_REPOSITORY                                         # e.g. username/imagename
+          export CHART_REGISTRY=$CHART_REGISTRY                                             # e.g. ghcr.io
+          export CHART_REGISTRY_USERNAME=${{ inputs.chart-registry-username }}              # e.g. username
+          export CHART_REGISTRY_PASSWORD=${{ inputs.chart-registry-password }}              # its a secret!
+          export CHART_REPOSITORY=$CHART_REPOSITORY                                         # e.g. f2calv/cas/charts/tickprocessor
+          export CHART_NAME=$(basename $CHART_REPOSITORY)                                   # e.g. tickprocessor
+          export NAMESPACE=${{ inputs.namespace }}                                          # e.g. dev, tst, prd, etc...
+          export MANIFEST_PATH_RENDERED="$MANIFEST_PATH.manifest"                           # e.g. src/workloads/tickprocessor.yaml.manifest
 
-          cat $MANIFEST_PATH
+          #custom variables derived from inputs
+          export IMAGE_PREFIX=$IMAGE_REGISTRY/$IMAGE_REPOSITORY                             # e.g. ghcr.io/username/imagename
+          if [[ -z "$TAG_OVERRIDE" ]]; then
+            export IMAGE=$IMAGE_PREFIX:$TAG                                                 # e.g. ghcr.io/username/imagename:1.2.3
+          else
+            export IMAGE=$IMAGE_PREFIX:$TAG_OVERRIDE                                        # e.g. ghcr.io/username/imagename:latest-dev
+          fi
+
+          printf "\nIMAGE_REGISTRY=$IMAGE_REGISTRY"
+          printf "\nIMAGE_REPOSITORY=$IMAGE_REPOSITORY"
+          printf "\nTAG=$TAG"
+          printf "\nTAG_OVERRIDE=$TAG_OVERRIDE"
+          printf "\nIMAGE=$IMAGE"
+          printf "\nNAMESPACE=$NAMESPACE"
+          printf "\n-------------------------------------------"
+
+          KIND=$(yq '.kind' $MANIFEST_PATH)
+          #TODO: also validate that the key variables below are not empty for helm charts
+          if [[ "$KIND" == "Application" ]]; then
+            #we are updating an ArgoCD application manifest
+
+            printf "\nCHART_REGISTRY=$CHART_REGISTRY"
+            printf "\nCHART_REGISTRY_USERNAME=$CHART_REGISTRY_USERNAME"
+            printf "\nCHART_REGISTRY_PASSWORD=***" #Note: value redacted from logs to avoid leaking credentials
+            printf "\nCHART_REPOSITORY=$CHART_REPOSITORY"
+            printf "\nCHART_NAME=$CHART_NAME"
+            printf "\nMANIFEST_PATH_RENDERED=$MANIFEST_PATH_RENDERED"
+            printf "\n-------------------------------------------\n"
+
+            #yq -i '.metadata.name=env(CHART_NAME)' $MANIFEST_PATH
+
+            yq -i '.spec.destination.namespace=env(NAMESPACE)' $MANIFEST_PATH
+            yq -i '.spec.source.repoURL=env(CHART_REGISTRY)' $MANIFEST_PATH
+            yq -i '.spec.source.chart=env(CHART_REPOSITORY)' $MANIFEST_PATH
+            yq -i '.spec.source.targetRevision=env(TAG)' $MANIFEST_PATH
+
+            # yq -i '.spec.source.helm.parameters[] |= select(.name == "image.repository").value=env(CHART_REPOSITORY)' $MANIFEST_PATH
+            # yq -i '.spec.source.helm.parameters[] |= select(.name == "image.tag").value=env(TAG)' $MANIFEST_PATH
+
+            cat $MANIFEST_PATH
+
+            yq '.spec.source.helm.valuesObject' $MANIFEST_PATH >> temp.values.yaml
+
+            printf "\n\n>helm registry login $CHART_REGISTRY --username $CHART_REGISTRY_USERNAME --password-stdin\n"
+            printf $CHART_REGISTRY_PASSWORD | helm registry login $CHART_REGISTRY --username $CHART_REGISTRY_USERNAME --password-stdin
+
+            printf "\n\n>helm pull oci://$CHART_REGISTRY/$CHART_REPOSITORY --version $TAG --untar\n"
+            helm pull oci://$CHART_REGISTRY/$CHART_REPOSITORY --version $TAG --untar --destination temp-charts
+
+            printf "\n\n>helm template --namespace $NAMESPACE $CHART_NAME $CHART_REPOSITORY --values temp.values.yaml > $MANIFEST_PATH_RENDERED\n"
+            helm template --namespace $NAMESPACE $CHART_NAME temp-charts/$CHART_NAME --values temp.values.yaml > $MANIFEST_PATH_RENDERED
+
+            cat $MANIFEST_PATH_RENDERED
+
+            #we are in a loop so do some clean up
+            rm -rf temp.values.yaml
+            rm -rf temp-charts
+          else
+            #we are updating a regular kubernetes manifest
+
+            #update the image repository
+            yq -i '. | select(.kind == "Deployment") as $deployment | select(.kind != "Deployment") as $other | $deployment.spec.template.spec.containers[] |= select(.name == "primary").image=env(IMAGE) | ($deployment, $other)' $MANIFEST_PATH
+
+            #update the TAG env variable so we can track a deployment of a new image that has it's full sem ver tag overriden by tagged tag-override, e.g. latest-dev
+            yq -i '. | select(.kind == "Deployment") as $deployment | select(.kind != "Deployment") as $other | $deployment.spec.template.spec.containers[] |= select(.name == "primary").env[] |= select(.name == "TAG").value=env(TAG) | ($deployment, $other)' $MANIFEST_PATH
+
+            #update all namespaces
+            yq -i '.metadata.namespace=env(NAMESPACE)' $MANIFEST_PATH
+
+            cat $MANIFEST_PATH
+          fi
 
         done
+      shell: bash
 
     - name: repo update
       if: inputs.git-repo-update == 'true'
       shell: bash
       run: |
+        cd ${{ inputs.git-working-directory }}
         if [[ -n "$(git status --porcelain)" ]]; then
           git config --global user.name "${{ inputs.git-user-name }}"
           git config --global user.email "${{ inputs.git-user-email }}"
           git checkout ${{ inputs.git-branch-name }}
           git add --all
-          git commit -m "bump '${{ inputs.image-repository }}' to '${{ inputs.tag }}'"
+          git commit -m "[${{ inputs.namespace }}] bump '${{ inputs.image-repository }}' to '${{ inputs.tag }}'"
           git push -v --progress
         else
           echo "::warning title=git push::No changes to push."

--- a/action.yml
+++ b/action.yml
@@ -2,18 +2,14 @@ name: gha-gitops-manifest-update
 description: Updates image tags in gitops manifests and optionally pushes changes to the git repository.
 
 inputs:
-  registry:
+  image-registry:
     type: string
     description: e.g. ghcr.io/gh-user, xyz.azurecr.io or docker.io
     required: true
-  repository:
+  image-repository:
     type: string
-    description: Accepts multiple deployment names when separated by a space e.g. deploy1 deploy2 deploy3
+    description: e.g. [optional-prefix/]myimage
     required: true
-  repository-prefix:
-    type: string
-    description: e.g. prefix/
-    default: ''
   tag:
     type: string
     description: e.g. latest, latest-dev, 1.2.3
@@ -34,7 +30,7 @@ inputs:
     type: string
     description: e.g. 1.2.301-feature-my-feature.12
     required: true
-  git-repository-push-enabled:
+  git-repo-update:
     type: boolean
     description: If 'false' then skips the git operations entirely, e.g. action runs in demo mode
     default: true
@@ -84,8 +80,8 @@ runs:
     - name: manipulate deployment
       shell: bash
       run: |
-        echo "repositories=${{ inputs.repository }}"
-        REPOSITORIES=(${{ inputs.repository }})
+        echo "repositories=${{ inputs.image-repository }}"
+        REPOSITORIES=(${{ inputs.image-repository }})
         for chartname in "${REPOSITORIES[@]}"
         do
 
@@ -97,9 +93,9 @@ runs:
             echo "now processing chart..."
             export CHART_NAME=$chartname                                             # e.g. authenticator
             export MANIFEST_PATH=${{ inputs.manifest-path }}/$manifestpath.yaml      # e.g. src/workloads/authenticator.yaml
-            export CHART_REPOSITORY=${{ inputs.repository-prefix }}$CHART_NAME # e.g. cas/charts/authenticator
-            export REGISTRY=${{ inputs.registry }}                                   # e.g. ghcr.io/f2calv
-            export REPOSITORY=$REGISTRY/${{ inputs.repository-prefix }}$CHART_NAME   # e.g. ghcr.io/f2calv/cas/authenticator
+            export CHART_REPOSITORY=$CHART_NAME # e.g. cas/charts/authenticator
+            export REGISTRY=${{ inputs.image-registry }}                             # e.g. ghcr.io/f2calv
+            export REPOSITORY=$REGISTRY/$CHART_NAME                                  # e.g. ghcr.io/f2calv/authenticator
             export TAG=${{ inputs.tag }}                                             # e.g. 1.2.3
             export IMAGE=$REPOSITORY:$TAG                                            # e.g. ghcr.io/f2calv/cas/authenticator:1.2.3
   
@@ -129,7 +125,7 @@ runs:
         done
 
     - name: repo update
-      if: inputs.git-repository-push-enabled == 'true'
+      if: inputs.git-repo-update == 'true'
       shell: bash
       run: |
         if [[ -n "$(git status --porcelain)" ]]; then
@@ -137,7 +133,7 @@ runs:
           git config --global user.name "${{ inputs.git-user-name }}"
           git checkout ${{ inputs.git-branch-name }}
           git add --all
-          git commit -m "bump '${{ inputs.repository }}' to '${{ inputs.tag }}'"
+          git commit -m "bump '${{ inputs.image-repository }}' to '${{ inputs.tag }}'"
           git push -v --progress
         else
           echo "::warning title=git push::No changes to push."

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
     type: string
     description: e.g. [optional-prefix/]myimage
     required: true
-  tag:
+  tag-override:
     type: string
     description: e.g. latest, latest-dev, 1.2.3
     required: true
@@ -26,7 +26,7 @@ inputs:
     type: string
     description: e.g. src/workloads
     required: true
-  fullSemVer:
+  tag:
     type: string
     description: e.g. 1.2.301-feature-my-feature.12
     required: true
@@ -96,7 +96,7 @@ runs:
             export CHART_REPOSITORY=$CHART_NAME # e.g. cas/charts/authenticator
             export REGISTRY=${{ inputs.image-registry }}                             # e.g. ghcr.io/f2calv
             export REPOSITORY=$REGISTRY/$CHART_NAME                                  # e.g. ghcr.io/f2calv/authenticator
-            export TAG=${{ inputs.tag }}                                             # e.g. 1.2.3
+            export TAG=${{ inputs.tag-override }}                                    # e.g. 1.2.3
             export IMAGE=$REPOSITORY:$TAG                                            # e.g. ghcr.io/f2calv/cas/authenticator:1.2.3
   
             echo "CHART_NAME=$CHART_NAME"
@@ -116,7 +116,7 @@ runs:
             yq -i '. | select(.kind == "Deployment") as $deployment | select(.kind != "Deployment") as $other | $deployment.spec.template.spec.containers[] |= select(.name == "primary").image=env(IMAGE) | ($deployment, $other)' $MANIFEST_PATH
   
             #update the GIT_TAG env variable so we can track a deployment of new image tagged with latest-dev
-            FULLSEMVER=${{ inputs.fullSemVer }}
+            FULLSEMVER=${{ inputs.tag }}
             FULLSEMVER=$FULLSEMVER yq -i '. | select(.kind == "Deployment") as $deployment | select(.kind != "Deployment") as $other | $deployment.spec.template.spec.containers[] |= select(.name == "primary").env[] |= select(.name == "FULLSEMVER").value=env(FULLSEMVER) | ($deployment, $other)' $MANIFEST_PATH
   
             cat $MANIFEST_PATH
@@ -133,7 +133,7 @@ runs:
           git config --global user.name "${{ inputs.git-user-name }}"
           git checkout ${{ inputs.git-branch-name }}
           git add --all
-          git commit -m "bump '${{ inputs.image-repository }}' to '${{ inputs.tag }}'"
+          git commit -m "bump '${{ inputs.image-repository }}' to '${{ inputs.tag-override }}'"
           git push -v --progress
         else
           echo "::warning title=git push::No changes to push."

--- a/action.yml
+++ b/action.yml
@@ -72,20 +72,27 @@ runs:
     - name: setup yq (1 of 3)
       shell: bash
       run: |
-        FILE=${{ inputs.devcontainer-path }}
+        GIT_DIR="${{ inputs.git-working-directory }}"
+        GIT_DIR="${GIT_DIR%/}"
+        if [[ "$GIT_DIR" != "." ]]; then
+          FILE="$GIT_DIR/${{ inputs.devcontainer-path }}"
+        else
+          FILE="${{ inputs.devcontainer-path }}"
+        fi
         if [[ -f "$FILE" ]]; then
           echo "$FILE exists"
         else
-          echo "::error file=${{ inputs.devcontainer-path }}::yq version is managed by the devcontainer.json, '$FILE' is therefore required!"
+          echo "::error file=$FILE::yq version is managed by the devcontainer.json, '$FILE' is therefore required!"
           exit 1
         fi
+        echo "DEVCONTAINER_PATH=$FILE" >> $GITHUB_ENV
 
     - name: setup yq (2 of 3) #pull version from devcontainer.json
       shell: bash
       run: |
         npm install --global json5
-        json5 -c ${{ inputs.devcontainer-path }}
-        VERSION_TO_INSTALL=$(cat ${{ inputs.devcontainer-path }} | jq -r '.features[] | select(.yqVersion | . != null).yqVersion')
+        json5 -c ${{ env.DEVCONTAINER_PATH }}
+        VERSION_TO_INSTALL=$(cat ${{ env.DEVCONTAINER_PATH }} | jq -r '.features[] | select(.yqVersion | . != null).yqVersion')
         echo "VERSION_TO_INSTALL=$VERSION_TO_INSTALL" >> $GITHUB_ENV
         echo "VERSION_TO_INSTALL=$VERSION_TO_INSTALL"
 
@@ -98,7 +105,7 @@ runs:
     - name: setup helm (1 of 2) #pull version from devcontainer.json
       shell: bash
       run: |
-        HELM_VERSION=$(cat ${{ inputs.devcontainer-path }} | jq -r '.features[] | select(.helm | . != null).helm')
+        HELM_VERSION=$(cat ${{ env.DEVCONTAINER_PATH }} | jq -r '.features[] | select(.helm | . != null).helm')
         echo "HELM_VERSION=$HELM_VERSION" >> $GITHUB_ENV
         echo "HELM_VERSION=$HELM_VERSION"
 


### PR DESCRIPTION
## Commits

| Hash | Message | Author | Date |
| --- | --- | --- | --- |
| `31d7761` | fix devcontainer.json path | Alex Vincent | 2026-04-01 |
| `7015fc4` | misc updates | Alex Vincent | 2026-04-01 |
| `69c7c58` | update copilot instructions | Alex Vincent | 2026-03-31 |
| `8bc6a26` | +semver:feature big update taken from KNX repo | Alex Vincent | 2026-03-31 |
| `656f95a` | standardize | Alex Vincent | 2026-03-31 |
| `66a4efe` | tidy | Alex Vincent | 2026-03-31 |
| `9857cce` | update comment | Alex Vincent | 2026-03-31 |
| `f1a22a9` | change paths | Alex Vincent | 2026-03-31 |
| `00ec4d8` | rename tag inputs | Alex Vincent | 2026-03-31 |
| `1c33f2f` | renamed inputs | Alex Vincent | 2026-03-31 |

## Files Changed

| File | Change | Insertions | Deletions |
| --- | --- | --- | --- |
| `.github/copilot-instructions.md` | Added | 71 | 0 |
| `.github/prompts/summarize-for-pr.prompt.md` | Modified | 1 | 1 |
| `GitVersion.yml` | Modified | 5 | 5 |
| `README.md` | Modified | 64 | 28 |
| `action.yml` | Modified | 178 | 66 |

_5 files changed, 319 insertions, 100 deletions._

## Change Details

### `action.yml` — Major action redesign (v1 → v2)

1. **Renamed and restructured inputs** — the flat `registry`/`repository`/`repository-prefix`/`manifest`/`manifest-path`/`fullSemVer`/`git-repository-push-enabled` inputs have been replaced with grouped, kebab-case equivalents: `image-registry`, `image-repository`, `tag`, `tag-override`, `chart-registry`, `chart-registry-username`, `chart-registry-password`, `chart-repository`, `manifest-paths`, `namespace`, `git-repo-update`, and `git-working-directory`.
2. **Added ArgoCD Application support** — the main processing loop now detects the manifest `kind`. For `Application` manifests it updates `spec.source.targetRevision`, `repoURL`, `chart`, and `destination.namespace` via yq, then pulls the Helm chart from an OCI registry and renders it to a `.manifest` sidecar file.
3. **Added Helm tooling** — new `setup helm (1 of 2)` and `setup helm (2 of 2)` steps extract the Helm version from `devcontainer.json` and install it via `azure/setup-helm@v5`.
4. **Added `tag-override` support** — when `tag-override` is set, the container image uses that tag (e.g. `latest-dev`) while the raw `tag` value is still written to the `TAG` env var for traceability. Previously only `fullSemVer` was written.
5. **Added `git-working-directory` input** — allows the action to operate inside a subdirectory (e.g. `gitops/`), with manifest paths and devcontainer path automatically prefixed.
6. **Added `namespace` input** — writes the destination namespace into every manifest (`metadata.namespace` for Deployments, `spec.destination.namespace` for ArgoCD Applications).
7. **Replaced `FULLSEMVER` env var with `TAG`** — the yq command that stamps the env var on Deployment containers now writes `TAG` instead of `FULLSEMVER`.
8. **Forced OCI values to lowercase** — registry and repository values are lowercased with `${VAR,,}` before use, following security best practices.
9. **Updated description** — now reads _"Iterates over YAML manifests (Kubernetes Deployment or ArgoCD Application) and updates their image/tag - also renders manifests."_
10. **Changed git commit message format** — includes `namespace` prefix: `[$NAMESPACE] bump '$IMAGE_REPOSITORY' to '$TAG'`.

### `README.md` — Full rewrite to match v2 inputs

1. **Updated action description** — reflects ArgoCD Application support and Helm chart rendering alongside Deployment image updates.
2. **Replaced usage examples** — three examples now cover Deployment-only, Deployment with `tag-override`, and ArgoCD Application with Helm chart pull/render.
3. **Restructured inputs table** — inputs are grouped under Image, Chart, Manifest, Tooling, and Git sub-headings with individual tables per group.
4. **Removed obsolete inputs** — `registry`, `repository`, `repository-prefix`, `manifest`, `manifest-path`, `fullSemVer`, `git-repository-push-enabled` are no longer documented.
5. **Added new inputs to documentation** — `tag-override`, `chart-registry`, `chart-registry-username`, `chart-registry-password`, `chart-repository`, `manifest-paths`, `namespace`, `git-repo-update`, `git-working-directory`.

### `GitVersion.yml` — Configuration modernised

1. **Changed mode** from `MainLine` to `ContinuousDeployment`.
2. **Renamed `tag` keys to `label`** across all branch configs (`main`, `feature`, `preview`) to match GitVersion v6 schema.
3. **Removed unnecessary quoting** — `source-branches` values changed from `["main"]` to `[main]`.

### `.github/copilot-instructions.md` — Added repository Copilot instructions

1. **New file** — establishes coding conventions for this repo covering GitHub Actions style, step naming, naming conventions, YAML style, reusable workflows, composite actions, security, GitVersion, README consistency, and git history preservation.

### `.github/prompts/summarize-for-pr.prompt.md` — Minor wording fix

1. **Updated description** — changed `"vs. master"` to `"vs. main/master"` to reflect that the default branch may be either name.